### PR TITLE
Fix noise seed field link

### DIFF
--- a/Textures/src/com/beder/texture/Operation.java
+++ b/Textures/src/com/beder/texture/Operation.java
@@ -17,10 +17,12 @@ import javax.swing.JSlider;
 import javax.swing.JTextField;
 
 public abstract class Operation implements Comparable<Operation> {
-	private Parameters param;
-	private Redrawable redraw;
-	private JPanel controlPanel;
-	private Map<String, Component> controls;
+        private Parameters param;
+        private Redrawable redraw;
+        private JPanel controlPanel;
+        private Map<String, Component> controls;
+        /** Text field used when a SEED parameter is added. */
+        protected JTextField seedField;
 	protected enum CONTROL_TYPE {INT, DOUBLE, SLIDER, SEED};
 	
 	public Operation(Redrawable redraw){
@@ -42,8 +44,8 @@ public abstract class Operation implements Comparable<Operation> {
 			controls.put(name, doubleField);
 			controlPanel.add(doubleField);
 			break;
-	    case SLIDER:
-	        JSlider slider = new JSlider(0, 100, (int) def);
+            case SLIDER:
+                JSlider slider = new JSlider(0, 100, (int) def);
 	        slider.setMajorTickSpacing(20);
 	        slider.setMinorTickSpacing(5);
 	        slider.setPaintTicks(true);
@@ -51,17 +53,17 @@ public abstract class Operation implements Comparable<Operation> {
 	        controls.put(name, slider);
 	        controlPanel.add(slider);
 	        break;
-		case SEED:
-			JTextField seedField = new JTextField(String.format("%d", (long)def), 8); // FIX: store to seedField
-		    controls.put(name, seedField);
-		    controlPanel.add(seedField);
-		    JButton randomSeedButton = new JButton("Random");
-		    randomSeedButton.addActionListener(e -> {
-		        String newSeed = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
-		        seedField.setText(newSeed);
-		    });
-		    controlPanel.add(randomSeedButton);
-		    break;
+                case SEED:
+                    seedField = new JTextField(String.format("%d", (long)def), 8);
+                    controls.put(name, seedField);
+                    controlPanel.add(seedField);
+                    JButton randomSeedButton = new JButton("Random");
+                    randomSeedButton.addActionListener(e -> {
+                        String newSeed = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+                        seedField.setText(newSeed);
+                    });
+                    controlPanel.add(randomSeedButton);
+                    break;
 		default:
 			break;
 		}
@@ -133,9 +135,17 @@ public abstract class Operation implements Comparable<Operation> {
 		return hash1 - hash2;
 	}
 
-	public Redrawable getRedraw() {
-		return redraw;
-	}
-	
-	
+        public Redrawable getRedraw() {
+                return redraw;
+        }
+
+        /**
+         * Returns the text field created when a SEED parameter was added.
+         * May be {@code null} if no such parameter exists.
+         */
+        public JTextField getSeedField() {
+                return seedField;
+        }
+
+
 }

--- a/Textures/src/com/beder/texture/noise/NoiseOperation.java
+++ b/Textures/src/com/beder/texture/noise/NoiseOperation.java
@@ -6,7 +6,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.TreeMap;
 
-import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
@@ -17,20 +16,20 @@ import com.beder.texture.Redrawable;
 
 public abstract class NoiseOperation extends Operation {
 
-	private JTextField seedField;
-	private JButton randomSeedButton;
-	private BufferedImage result;
-	private ImagePair input;
+        private BufferedImage result;
+        private ImagePair input;
 	private Parameters lastPar;
 	private final static String PARAM_SEED = "Seed";
 
-	public NoiseOperation(Redrawable r) {
-		super(r);
-		result = null;
-		lastPar = new Parameters();
-		long seed = new Random().nextInt(Integer.MAX_VALUE);
-		addParameter(PARAM_SEED, CONTROL_TYPE.SEED, seed);
-	}
+        public NoiseOperation(Redrawable r) {
+                super(r);
+                result = null;
+                lastPar = new Parameters();
+                long seed = new Random().nextInt(Integer.MAX_VALUE);
+                addParameter(PARAM_SEED, CONTROL_TYPE.SEED, seed);
+                // retrieve reference to the seed field for convenience
+                this.seedField = getSeedField();
+        }
 
     /**
      * Called by child class to add random seed controls on the edit panel
@@ -73,10 +72,17 @@ public abstract class NoiseOperation extends Operation {
 	    return input;
 	}
 
-	public long getSeed() {
-        long seed = Long.parseLong(seedField.getText());
-		return seed;
-	}
+        public long getSeed() {
+                JTextField tf = this.seedField;
+                if (tf == null) {
+                        return 0L;
+                }
+                try {
+                        return Long.parseLong(tf.getText());
+                } catch (NumberFormatException e) {
+                        return 0L;
+                }
+        }
 
 	public ImagePair getInput() {
 		return input;


### PR DESCRIPTION
## Summary
- link seed text field to `NoiseOperation`
- expose seed field from `Operation`

## Testing
- `javac -classpath "lib/*" -d classes @sources.txt` *(fails: lib missing)*
- `../mvnw -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6844d448371c8327801c68b4c22c6d38