### PR TITLE
Add File menu with stack persistence

### DIFF
--- a/Textures/build.gradle.kts
+++ b/Textures/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
 dependencies {
     implementation(libs.org.locationtech.jts.jts.core)
     implementation("com.miglayout:miglayout-swing:5.3")
+    implementation("org.json:json:20231013")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
 }

--- a/Textures/software_design_document.txt
+++ b/Textures/software_design_document.txt
@@ -89,6 +89,7 @@ The software is a texture generator that allows users to apply various operation
     - `ImagePair curImage`: Currently displayed image pair.
     - `boolean isDirty`: State of unsaved changes.
     - `TextureGUI gui`: Reference to the GUI.
+    - `File stackFile`: Last used JSON file for saving/loading the stack.
 
 - **Constructors:**
     - `TextureGenius(int res)`: Initializes the texture generator with a specified resolution.
@@ -101,6 +102,8 @@ The software is a texture generator that allows users to apply various operation
     - `ImagePair addOperation(Operation op)`: Adds and executes new operations.
     - `ImagePair applyCurrent()`: Applies the current process.
     - `ImagePair saveCurrent()`: Saves the current operation and marks clean.
+    - `void reset()`: Clears the stack and resets images.
+    - `void saveStack(File) / loadStack(File)`: Persist or restore the operation stack in JSON.
 
 ### 8. TextureGUI.java
 - **Properties:**
@@ -108,13 +111,15 @@ The software is a texture generator that allows users to apply various operation
     - `int res`: Resolution of images.
     - `ImagePair curImage`: Current image to display.
     - `JFrame frame`: Main GUI window.
+    - `JMenuBar menuBar`: Top-level menu bar with a File menu.
     - `JPanel mainPanel`, `imagePanel`, `opControlPanel`: Various panels for organizing the UI.
 
 - **Methods:**
-    - `void init()`: Initializes and displays the GUI.
+    - `void init()`: Initializes and displays the GUI and builds the File menu.
     - `void showOptions()`: Displays parameters for the selected operation.
     - `void applyImage(ImagePair current)`: Updates the displayed images based on the current `ImagePair`.
     - `int getRes()`: Returns the resolution.
+    - Menu actions for New, Open, Save, Save As, and Close call the corresponding `TextureGenius` methods.
 
 ### 9. Scatter related classes
 #### ScatterOperation.java

--- a/Textures/software_requirements_document.txt
+++ b/Textures/software_requirements_document.txt
@@ -57,8 +57,16 @@ Textures is a Java application that provides functionalities for creating and ma
   - **FR-21.5**: When the user clicks Generate, the system shall overlay Quantity sprites onto the current image using these rules:  
     1. Weighted Selection: each sprite is chosen randomly in proportion to its Weight divided by the sum of all Weights.  
     2. Gaussian Size: each sprite’s width is drawn from N(mean=Size, sd=StandardDeviation).  
-    3. Random Rotation: each sprite is rotated by a random angle [0°,360°).  
+    3. Random Rotation: each sprite is rotated by a random angle [0°,360°).
     4. Toroidal Wrapping: any portion of a pasted sprite crossing an edge reappears on the opposite side.
+
+### 10. File Menu
+- **FR-22**: The application shall provide a menu bar with a **File** dropdown.
+- **FR-23**: Choosing **New** shall clear the operation stack and reset both images to black.
+- **FR-24**: Choosing **Open** shall prompt for a JSON file describing an operations stack and apply all operations.
+- **FR-25**: Choosing **Save** shall write the current operations stack to a JSON file, overwriting the previous save if it exists.
+- **FR-26**: Choosing **Save As** shall always prompt for a destination JSON file and then save the operations stack.
+- **FR-27**: Choosing **Close** shall exit the application window.
 
 ## Technical Requirements
 
@@ -139,6 +147,13 @@ Each noise class must:
 ### 6. Scatter Operation
 - **TR-6.1**: In `TextureGUI.init()`, add a Scatter button next to the other operation buttons. Its action listener must call `addOperation(new ScatterOperation(this));`.
 - **TR-6.2**: In `TextureGUI`, add a Configure Scatter button that opens a modal dialog. This dialog must show sprite previews with Weight fields and a Save button to persist them; once saved, the Scatter operation’s Generate button becomes enabled.
+
+### 7. File Menu
+- **TR-7.1**: `TextureGUI` shall create a `JMenuBar` containing a File menu with items New, Open, Save, Save As, and Close.
+- **TR-7.2**: Implement `TextureGenius.reset()` to clear the `LayerStack`, reinitialize the images, and rebuild the UI.
+- **TR-7.3**: Implement `TextureGenius.saveStack(File)` and `loadStack(File)` to serialize and deserialize the operation stack as JSON.
+- **TR-7.4**: The Save menu item shall use the previously chosen file if available; otherwise it behaves like Save As.
+- **TR-7.5**: The Close menu item shall dispose the main application window.
 
 ---
 

--- a/Textures/src/com/beder/texture/LayerStack.java
+++ b/Textures/src/com/beder/texture/LayerStack.java
@@ -35,9 +35,21 @@ public class LayerStack {
 		thisPanel.add(stackPanel);
 	}
 	
-	public JPanel getStackPanel() {
-		return thisPanel;
-	}
+        public JPanel getStackPanel() {
+                return thisPanel;
+        }
+
+        /** Clear all layers from the stack and reset the pointer. */
+        public void clear() {
+                stack.clear();
+                curPtr = -1;
+                buildStackPanel();
+        }
+
+        /** Returns a copy of the current layer list. */
+        public java.util.List<Layer> getLayers() {
+                return new ArrayList<>(stack);
+        }
 	
 	/***
 	 *  Rebuilds all of the stack tiles on the UI

--- a/Textures/src/com/beder/texture/TextureGUI.java
+++ b/Textures/src/com/beder/texture/TextureGUI.java
@@ -52,6 +52,23 @@ public class TextureGUI implements Redrawable {
         frame = new JFrame("Texture Generator");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
+        // --- Menu Bar ---
+        JMenuBar menuBar = new JMenuBar();
+        JMenu fileMenu = new JMenu("File");
+        JMenuItem newItem = new JMenuItem("New");
+        JMenuItem openItem = new JMenuItem("Open");
+        JMenuItem saveItem = new JMenuItem("Save");
+        JMenuItem saveAsItem = new JMenuItem("Save As");
+        JMenuItem closeItem = new JMenuItem("Close");
+        fileMenu.add(newItem);
+        fileMenu.add(openItem);
+        fileMenu.add(saveItem);
+        fileMenu.add(saveAsItem);
+        fileMenu.addSeparator();
+        fileMenu.add(closeItem);
+        menuBar.add(fileMenu);
+        frame.setJMenuBar(menuBar);
+
         mainPanel = new JPanel(new BorderLayout());
 
         // Center: image display with arrows
@@ -142,6 +159,59 @@ public class TextureGUI implements Redrawable {
         frame.pack();
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
+
+        // Menu actions
+        newItem.addActionListener(e -> {
+            genius.reset();
+            applyImage(genius.getCurrentImage());
+            showOptions();
+        });
+
+        openItem.addActionListener(e -> {
+            JFileChooser ch = new JFileChooser();
+            if (ch.showOpenDialog(frame) == JFileChooser.APPROVE_OPTION) {
+                try {
+                    genius.loadStack(ch.getSelectedFile());
+                    applyImage(genius.getCurrentImage());
+                    showOptions();
+                } catch (Exception ex) {
+                    JOptionPane.showMessageDialog(frame,
+                            "Failed to open file: " + ex.getMessage(),
+                            "Open Error", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        });
+
+        saveItem.addActionListener(e -> {
+            File f = genius.getStackFile();
+            if (f == null) {
+                JFileChooser ch = new JFileChooser();
+                if (ch.showSaveDialog(frame) != JFileChooser.APPROVE_OPTION) return;
+                f = ch.getSelectedFile();
+            }
+            try {
+                genius.saveStack(f);
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(frame,
+                        "Failed to save file: " + ex.getMessage(),
+                        "Save Error", JOptionPane.ERROR_MESSAGE);
+            }
+        });
+
+        saveAsItem.addActionListener(e -> {
+            JFileChooser ch = new JFileChooser();
+            if (ch.showSaveDialog(frame) == JFileChooser.APPROVE_OPTION) {
+                try {
+                    genius.saveStack(ch.getSelectedFile());
+                } catch (IOException ex) {
+                    JOptionPane.showMessageDialog(frame,
+                            "Failed to save file: " + ex.getMessage(),
+                            "Save Error", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        });
+
+        closeItem.addActionListener(e -> frame.dispose());
 
         // --- Action Listeners ---
         saveButton.addActionListener(e -> {

--- a/Textures/src/com/beder/texture/TextureGenius.java
+++ b/Textures/src/com/beder/texture/TextureGenius.java
@@ -1,6 +1,10 @@
 package com.beder.texture;
 
 import javax.swing.JPanel;
+import org.json.*;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 /**
  * TextureGenius handles all control and logic: managing the operation stack,
@@ -12,7 +16,8 @@ public class TextureGenius {
     private final LayerStack stack;
     private ImagePair curImage;
     private boolean isDirty;
-	private TextureGUI gui;
+    private java.io.File stackFile;
+        private TextureGUI gui;
 
     public static void main(String[] args) {
         // Initialize logic and launch GUI
@@ -112,6 +117,63 @@ public class TextureGenius {
      */
     public ImagePair getCurrentImage() {
         return curImage;
+    }
+
+    /** Reset the stack and images to a blank state. */
+    public void reset() {
+        stack.clear();
+        curImage = new ImagePair(res);
+        isDirty = false;
+        stackFile = null;
+        gui.applyImage(curImage);
+    }
+
+    /** Returns the file used for stack persistence. */
+    public java.io.File getStackFile() { return stackFile; }
+
+    /** Save the current operation stack to the given file in JSON format. */
+    public void saveStack(java.io.File file) throws IOException {
+        org.json.JSONArray arr = new org.json.JSONArray();
+        for (Layer l : stack.getLayers()) {
+            org.json.JSONObject obj = new org.json.JSONObject();
+            obj.put("class", l.getOperation().getClass().getName());
+            org.json.JSONObject params = new org.json.JSONObject();
+            for (java.util.Map.Entry<String,Double> e : l.getParam().entrySet()) {
+                params.put(e.getKey(), e.getValue());
+            }
+            obj.put("params", params);
+            arr.put(obj);
+        }
+        org.json.JSONObject root = new org.json.JSONObject();
+        root.put("operations", arr);
+        try (java.io.FileWriter fw = new java.io.FileWriter(file)) {
+            fw.write(root.toString(2));
+        }
+        stackFile = file;
+    }
+
+    /** Load an operation stack from the given JSON file. */
+    public void loadStack(java.io.File file) throws Exception {
+        reset();
+        String txt = new String(java.nio.file.Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        org.json.JSONObject root = new org.json.JSONObject(txt);
+        org.json.JSONArray arr = root.getJSONArray("operations");
+        for (int i = 0; i < arr.length(); i++) {
+            org.json.JSONObject obj = arr.getJSONObject(i);
+            String cls = obj.getString("class");
+            java.lang.Class<?> c = java.lang.Class.forName(cls);
+            java.lang.reflect.Constructor<?> cons = c.getConstructor(Redrawable.class);
+            Operation op = (Operation)cons.newInstance(gui);
+            addOperation(op);
+            org.json.JSONObject pObj = obj.getJSONObject("params");
+            Parameters p = new Parameters();
+            for (String key : pObj.keySet()) {
+                p.put(key, pObj.getDouble(key));
+            }
+            stack.getCurrent().setParam(p);
+            saveCurrent();
+        }
+        stackFile = file;
     }
 
 	public TextureGUI getGUI() {


### PR DESCRIPTION
## Summary
- add org.json library to build
- support clearing and loading operation stacks in LayerStack and TextureGenius
- add File menu to GUI with New/Open/Save/Save As/Close actions
- document File menu requirements and design

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6845dc98229c8327ba9f12eaea8ade3b