### PR TITLE
Fix scatter sprite dialog state

### DIFF
--- a/Textures/software_design_document.txt
+++ b/Textures/software_design_document.txt
@@ -136,17 +136,22 @@ The software is a texture generator that allows users to apply various operation
     - `JFrame dialog`: The dialog window.
     - `List<BufferedImage> uploadedImages`: Stores uploaded sprite images.
     - `Map<BufferedImage, Integer> weights`: The weights for each sprite.
+    - `TextureGUI owner`: Reference to the parent GUI for refreshing state.
 
 - **Methods:**
     - `void initDialog()`: Initializes and displays the dialog.
     - `void saveSpritesAndWeights()`: Saves the uploaded sprites and their weights.
+    - `void onAddSprites()`: Opens a file chooser starting at the last-used directory.
 
 #### SpriteRepository.java
 - **Properties:**
     - `Map<BufferedImage, Integer> spriteWeightMap`: Stores sprites with their weights.
+    - `File lastDirectory`: Remembers the last directory used to load sprites.
 
 - **Methods:**
     - `void addSprite(BufferedImage sprite, int weight)`: Adds a sprite to the collection.
+    - `void setLastDirectory(File dir)`: Update the last-used sprite directory.
+    - `File getLastDirectory()`: Retrieve the stored directory.
     - `List<BufferedImage> getRandomSprites(int quantity)`: Gets random sprites based on their weights.
 
 ### 10. Noise related classes

--- a/Textures/software_requirements_document.txt
+++ b/Textures/software_requirements_document.txt
@@ -54,11 +54,12 @@ Textures is a Java application that provides functionalities for creating and ma
     - Size (INT): average sprite width in pixels  
     - StandardDeviation (DOUBLE): SD for sprite-size Gaussian distribution  
     - Seed (SEED): random seed for reproducibility  
-  - **FR-21.5**: When the user clicks Generate, the system shall overlay Quantity sprites onto the current image using these rules:  
-    1. Weighted Selection: each sprite is chosen randomly in proportion to its Weight divided by the sum of all Weights.  
-    2. Gaussian Size: each sprite’s width is drawn from N(mean=Size, sd=StandardDeviation).  
+  - **FR-21.5**: When the user clicks Generate, the system shall overlay Quantity sprites onto the current image using these rules:
+    1. Weighted Selection: each sprite is chosen randomly in proportion to its Weight divided by the sum of all Weights.
+    2. Gaussian Size: each sprite’s width is drawn from N(mean=Size, sd=StandardDeviation).
     3. Random Rotation: each sprite is rotated by a random angle [0°,360°).
     4. Toroidal Wrapping: any portion of a pasted sprite crossing an edge reappears on the opposite side.
+  - **FR-21.6**: The Add Sprite file chooser shall open in the directory used during the previous sprite load session.
 
 ### 10. File Menu
 - **FR-22**: The application shall provide a menu bar with a **File** dropdown.

--- a/Textures/src/com/beder/texture/TextureGUI.java
+++ b/Textures/src/com/beder/texture/TextureGUI.java
@@ -108,7 +108,7 @@ public class TextureGUI implements Redrawable {
         // Configure Scatter dialog launcher
         loadImagesButton = new JButton("Load");
         loadImagesButton.addActionListener(e -> {
-            ConfigureScatterDialog dialog = new ConfigureScatterDialog(frame);
+            ConfigureScatterDialog dialog = new ConfigureScatterDialog(this, frame);
             dialog.setVisible(true);
         });
 

--- a/Textures/src/com/beder/texture/scatter/ConfigureScatterDialog.java
+++ b/Textures/src/com/beder/texture/scatter/ConfigureScatterDialog.java
@@ -1,5 +1,6 @@
 package com.beder.texture.scatter;
 
+import com.beder.texture.TextureGUI;
 import javax.imageio.ImageIO;
 import javax.swing.*;
 import java.awt.*;
@@ -11,14 +12,16 @@ import java.util.List;
 
 public class ConfigureScatterDialog extends JDialog {
     private final SpriteRepository repo;
+    private final TextureGUI owner;
     private final JPanel previewPanel;
     private final List<JTextField> weightFields;
     private final List<BufferedImage> loadedSprites;
     private final List<JPanel> spriteSlots;
     private JButton spriteSaveButton;
 
-    public ConfigureScatterDialog(JFrame parent) {
+    public ConfigureScatterDialog(TextureGUI owner, JFrame parent) {
         super(parent, "Configure Scatter Sprites", true);
+        this.owner = owner;
         repo = SpriteRepository.getInstance();
 
         // Initialize collections and preview panel
@@ -94,10 +97,15 @@ public class ConfigureScatterDialog extends JDialog {
     private void onAddSprites() {
         JFileChooser chooser = new JFileChooser();
         chooser.setMultiSelectionEnabled(true);
+        File last = repo.getLastDirectory();
+        if (last != null) {
+            chooser.setCurrentDirectory(last);
+        }
         chooser.setFileFilter(new javax.swing.filechooser.FileNameExtensionFilter(
             "Image files", ImageIO.getReaderFileSuffixes()
         ));
         if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            repo.setLastDirectory(chooser.getCurrentDirectory());
             for (File f : chooser.getSelectedFiles()) {
                 try {
                     BufferedImage img = ImageIO.read(f);
@@ -151,6 +159,7 @@ public class ConfigureScatterDialog extends JDialog {
                 repo.addSprite(loadedSprites.get(i), w);
             }
             dispose();
+            owner.showOptions();
         } catch (NumberFormatException ex) {
             JOptionPane.showMessageDialog(
                 this,

--- a/Textures/src/com/beder/texture/scatter/SpriteRepository.java
+++ b/Textures/src/com/beder/texture/scatter/SpriteRepository.java
@@ -1,6 +1,7 @@
 package com.beder.texture.scatter;
 
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -9,10 +10,12 @@ public class SpriteRepository {
     private static SpriteRepository instance;
     private final List<BufferedImage> sprites;
     private final List<Integer> weights;
+    private File lastDirectory;
 
     private SpriteRepository() {
         sprites = new ArrayList<>();
         weights = new ArrayList<>();
+        lastDirectory = new File(System.getProperty("user.home"));
     }
 
     public static synchronized SpriteRepository getInstance() {
@@ -58,6 +61,22 @@ public class SpriteRepository {
             sum += w;
         }
         return sum;
+    }
+
+    /**
+     * Remember the last directory used when loading sprites.
+     */
+    public synchronized File getLastDirectory() {
+        return lastDirectory;
+    }
+
+    /**
+     * Update the last directory. Ignores null or non-directories.
+     */
+    public synchronized void setLastDirectory(File dir) {
+        if (dir != null && dir.isDirectory()) {
+            lastDirectory = dir;
+        }
     }
 
     /**

--- a/Textures/src/test/java/com/beder/texture/scatter/SpriteRepositoryTest.java
+++ b/Textures/src/test/java/com/beder/texture/scatter/SpriteRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.beder.texture.scatter;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SpriteRepositoryTest {
+    @Test
+    public void testLastDirectorySetAndGet() {
+        SpriteRepository repo = SpriteRepository.getInstance();
+        File dir = new File(System.getProperty("java.io.tmpdir"));
+        repo.setLastDirectory(dir);
+        assertEquals(dir, repo.getLastDirectory());
+    }
+
+    @Test
+    public void testAddSpriteIncreasesCount() {
+        SpriteRepository repo = SpriteRepository.getInstance();
+        repo.clear();
+        BufferedImage img = new BufferedImage(2,2,BufferedImage.TYPE_INT_ARGB);
+        repo.addSprite(img, 1);
+        assertEquals(1, repo.getCount());
+    }
+}


### PR DESCRIPTION
## Summary
- remember the last directory when loading scatter sprites
- refresh scatter Generate button after saving sprites
- update design and requirements documents
- add `SpriteRepositoryTest` unit test

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6845e3db8ccc8327a52fb72e7b6b5f1a