### PR TITLE
Implement Add 4 sprite loading

### DIFF
--- a/Textures/software_design_document.txt
+++ b/Textures/software_design_document.txt
@@ -142,6 +142,7 @@ The software is a texture generator that allows users to apply various operation
     - `void initDialog()`: Initializes and displays the dialog.
     - `void saveSpritesAndWeights()`: Saves the uploaded sprites and their weights.
     - `void onAddSprites()`: Opens a file chooser starting at the last-used directory.
+    - `void onAddFour()`: Loads one image, splits it into four equal sprites and adds them with default weights.
 
 #### SpriteRepository.java
 - **Properties:**

--- a/Textures/software_requirements_document.txt
+++ b/Textures/software_requirements_document.txt
@@ -60,6 +60,7 @@ Textures is a Java application that provides functionalities for creating and ma
     3. Random Rotation: each sprite is rotated by a random angle [0°,360°).
     4. Toroidal Wrapping: any portion of a pasted sprite crossing an edge reappears on the opposite side.
   - **FR-21.6**: The Add Sprite file chooser shall open in the directory used during the previous sprite load session.
+  - **FR-21.7**: The configuration dialog shall provide an "Add 4" button that loads one image and splits it into four sprites automatically.
 
 ### 10. File Menu
 - **FR-22**: The application shall provide a menu bar with a **File** dropdown.

--- a/Textures/src/com/beder/texture/scatter/ConfigureScatterDialog.java
+++ b/Textures/src/com/beder/texture/scatter/ConfigureScatterDialog.java
@@ -9,6 +9,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import com.beder.util.ImageSplitter;
 
 public class ConfigureScatterDialog extends JDialog {
     private final SpriteRepository repo;
@@ -46,11 +47,13 @@ public class ConfigureScatterDialog extends JDialog {
 
         // Controls
         JButton addButton    = new JButton("Add Sprite");
+        JButton addFourButton = new JButton("Add 4");
         JButton removeButton = new JButton("Remove Selected");
         spriteSaveButton          = new JButton("Save");
         JButton cancelButton = new JButton("Cancel");
 
         addButton.addActionListener(e -> onAddSprites());
+        addFourButton.addActionListener(e -> onAddFour());
         removeButton.addActionListener(e -> onRemoveSprites());
         spriteSaveButton.addActionListener(e -> onSave());
         cancelButton.addActionListener(e -> dispose());
@@ -58,6 +61,7 @@ public class ConfigureScatterDialog extends JDialog {
         // Layout panels
         JPanel topPanel = new JPanel();
         topPanel.add(addButton);
+        topPanel.add(addFourButton);
         topPanel.add(removeButton);
 
         JPanel bottomPanel = new JPanel();
@@ -124,6 +128,42 @@ public class ConfigureScatterDialog extends JDialog {
                         JOptionPane.ERROR_MESSAGE
                     );
                 }
+            }
+            previewPanel.revalidate();
+            previewPanel.repaint();
+            updateSaveState();
+        }
+    }
+
+    private void onAddFour() {
+        JFileChooser chooser = new JFileChooser();
+        File last = repo.getLastDirectory();
+        if (last != null) {
+            chooser.setCurrentDirectory(last);
+        }
+        chooser.setFileFilter(new javax.swing.filechooser.FileNameExtensionFilter(
+            "Image files", ImageIO.getReaderFileSuffixes()
+        ));
+        if (chooser.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
+            repo.setLastDirectory(chooser.getCurrentDirectory());
+            File f = chooser.getSelectedFile();
+            try {
+                BufferedImage img = ImageIO.read(f);
+                for (BufferedImage part : ImageSplitter.splitIntoFour(img)) {
+                    loadedSprites.add(part);
+                    JTextField weightField = new JTextField("10", 3);
+                    weightFields.add(weightField);
+                    JPanel slot = buildSpriteSlot(part, weightField);
+                    spriteSlots.add(slot);
+                    previewPanel.add(slot);
+                }
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(
+                    this,
+                    "Failed to load: " + f.getName(),
+                    "Load Error",
+                    JOptionPane.ERROR_MESSAGE
+                );
             }
             previewPanel.revalidate();
             previewPanel.repaint();

--- a/Textures/src/com/beder/util/ImageSplitter.java
+++ b/Textures/src/com/beder/util/ImageSplitter.java
@@ -1,0 +1,25 @@
+package com.beder.util;
+
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Utility for splitting images into equally sized parts. */
+public class ImageSplitter {
+    /**
+     * Splits the given image into four equally sized rectangles.
+     *
+     * @param img Source image
+     * @return list containing the four quadrants in order: top-left, top-right, bottom-left, bottom-right
+     */
+    public static List<BufferedImage> splitIntoFour(BufferedImage img) {
+        int w = img.getWidth() / 2;
+        int h = img.getHeight() / 2;
+        List<BufferedImage> parts = new ArrayList<>(4);
+        parts.add(img.getSubimage(0, 0, w, h));
+        parts.add(img.getSubimage(w, 0, img.getWidth() - w, h));
+        parts.add(img.getSubimage(0, h, w, img.getHeight() - h));
+        parts.add(img.getSubimage(w, h, img.getWidth() - w, img.getHeight() - h));
+        return parts;
+    }
+}

--- a/Textures/src/test/java/com/beder/util/ImageSplitterTest.java
+++ b/Textures/src/test/java/com/beder/util/ImageSplitterTest.java
@@ -1,0 +1,21 @@
+package com.beder.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.BufferedImage;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ImageSplitterTest {
+    @Test
+    public void splitIntoFourProducesQuadrants() {
+        BufferedImage img = new BufferedImage(8, 6, BufferedImage.TYPE_INT_ARGB);
+        List<BufferedImage> parts = ImageSplitter.splitIntoFour(img);
+        assertEquals(4, parts.size());
+        assertEquals(4, parts.get(0).getWidth());
+        assertEquals(3, parts.get(0).getHeight());
+        assertEquals(4, parts.get(3).getWidth());
+        assertEquals(3, parts.get(3).getHeight());
+    }
+}


### PR DESCRIPTION
## Summary
- allow Configure Scatter dialog to load four sprites from a single image via new **Add 4** button
- implement `ImageSplitter` utility and tests
- document Add 4 workflow in design and requirements docs

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6845e69162c08327bd393442a50c31f3