### PR TITLE
Fix save button export and add tests

### DIFF
--- a/Textures/software_design_document.txt
+++ b/Textures/software_design_document.txt
@@ -118,6 +118,7 @@ The software is a texture generator that allows users to apply various operation
     - `void init()`: Initializes and displays the GUI and builds the File menu.
     - `void showOptions()`: Displays parameters for the selected operation.
     - `void applyImage(ImagePair current)`: Updates the displayed images based on the current `ImagePair`.
+    - `void exportCurrentImage(File base)`: Writes the current images as `<name>_left.png` and `<name>_right.png`.
     - `int getRes()`: Returns the resolution.
     - Menu actions for New, Open, Save, Save As, and Close call the corresponding `TextureGenius` methods.
 

--- a/Textures/software_requirements_document.txt
+++ b/Textures/software_requirements_document.txt
@@ -33,7 +33,7 @@ Textures is a Java application that provides functionalities for creating and ma
 - **FR-14**: The system shall support clicking new layers in the stack to redisplay their output images and show their configuration panel.
 
 ### 6. Persistence and Export
-- **FR-15**: Upon saving, the system shall prompt the user for a base filename and save two PNG files, appending `_left.png` and `_right.png` to the chosen name.
+- **FR-15**: Upon saving, the system shall prompt the user for a base filename and save two PNG files, appending `_left.png` and `_right.png` to the chosen name using `TextureGUI.exportCurrentImage(...)`.
 - **FR-16**: The system shall handle file-save errors gracefully by displaying a Swing error dialog with the exception message.
 
 ### 7. Extensibility and Modularity

--- a/Textures/src/com/beder/texture/TextureGUI.java
+++ b/Textures/src/com/beder/texture/TextureGUI.java
@@ -125,30 +125,21 @@ public class TextureGUI implements Redrawable {
         generateButton = new JButton("Generate");
         saveButton  = new JButton("Save");
         saveButton.addActionListener(e -> {
-            // 1) Permanently apply the current operation in the stack
-            ImagePair img = genius.saveCurrent();                                  // :contentReference[oaicite:0]{index=0}:contentReference[oaicite:1]{index=1}
+            // Apply the current operation and then export the images
+            ImagePair img = genius.saveCurrent();
             applyImage(img);
 
-            // 2) Prompt the user for a file location
             JFileChooser chooser = new JFileChooser();
             chooser.setDialogTitle("Save Texture");
             chooser.setSelectedFile(new File("texture.png"));
             if (chooser.showSaveDialog(frame) == JFileChooser.APPROVE_OPTION) {
-                File base = chooser.getSelectedFile();
-                String name = base.getName().replaceFirst("(\\.[^.]+)?$", "");
-                File leftFile  = new File(base.getParentFile(), name + "_left.png");
-                File rightFile = new File(base.getParentFile(), name + "_right.png");
-
-                // 3) Write out both left/right images
                 try {
-                    ImageIO.write(curImage.left,  "png", leftFile);
-                    ImageIO.write(curImage.right, "png", rightFile);
+                    exportCurrentImage(chooser.getSelectedFile());
                 } catch (IOException ex) {
                     JOptionPane.showMessageDialog(
                         frame,
                         "Failed to save image: " + ex.getMessage(),
-                        "Save Error",
-                        JOptionPane.ERROR_MESSAGE
+                        "Save Error", JOptionPane.ERROR_MESSAGE
                     );
                 }
             }
@@ -212,12 +203,7 @@ public class TextureGUI implements Redrawable {
         });
 
         closeItem.addActionListener(e -> frame.dispose());
-
         // --- Action Listeners ---
-        saveButton.addActionListener(e -> {
-            ImagePair img = genius.saveCurrent();
-            applyImage(img);
-        });
         generateButton.addActionListener(e -> {
             ImagePair img = genius.applyCurrent();
             applyImage(img);
@@ -310,6 +296,17 @@ public class TextureGUI implements Redrawable {
     @Override
     public int getRes() {
         return res;
+    }
+
+    /**
+     * Export the current left and right images using the provided base file.
+     */
+    public void exportCurrentImage(java.io.File base) throws IOException {
+        String name = base.getName().replaceFirst("(\\.[^.]+)?$", "");
+        java.io.File leftFile  = new java.io.File(base.getParentFile(), name + "_left.png");
+        java.io.File rightFile = new java.io.File(base.getParentFile(), name + "_right.png");
+        javax.imageio.ImageIO.write(curImage.left,  "png", leftFile);
+        javax.imageio.ImageIO.write(curImage.right, "png", rightFile);
     }
 
 	@Override

--- a/Textures/src/test/java/test/ExportImageTest.java
+++ b/Textures/src/test/java/test/ExportImageTest.java
@@ -1,0 +1,42 @@
+package test;
+
+import com.beder.texture.TextureGenius;
+import com.beder.texture.TextureGUI;
+import com.beder.texture.ImagePair;
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExportImageTest {
+    @Test
+    public void exportWritesFiles() throws Exception {
+        TextureGenius genius = new TextureGenius(4);
+        TextureGUI gui = new TextureGUI(genius);
+        ImagePair pair = genius.getCurrentImage();
+        pair.left.setRGB(0, 0, 0xFF00FF00);
+        pair.right.setRGB(0, 0, 0xFFFF0000);
+
+        File base = File.createTempFile("tex", ".png");
+        base.deleteOnExit();
+        gui.exportCurrentImage(base);
+
+        String name = base.getName().replaceFirst("(\\.[^.]+)?$", "");
+        File left = new File(base.getParentFile(), name + "_left.png");
+        File right = new File(base.getParentFile(), name + "_right.png");
+
+        assertTrue(left.exists());
+        assertTrue(right.exists());
+
+        BufferedImage limg = ImageIO.read(left);
+        BufferedImage rimg = ImageIO.read(right);
+        assertEquals(0xFF00FF00, limg.getRGB(0, 0));
+        assertEquals(0xFFFF0000, rimg.getRGB(0, 0));
+
+        left.delete();
+        right.delete();
+    }
+}


### PR DESCRIPTION
## Summary
- export images through a new `exportCurrentImage` helper
- connect Save button to the new helper
- document export helper in design and requirements docs
- cover export behavior with a unit test

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6845e978897c832788bbd2dc6e7f3eda