### PR TITLE
Implement AO option in Scatter

### DIFF
--- a/Textures/software_design_document.txt
+++ b/Textures/software_design_document.txt
@@ -127,10 +127,18 @@ The software is a texture generator that allows users to apply various operation
 - **Properties:**
     - `List<BufferedImage> sprites`: Stores the user-provided sprite images.
     - `Map<BufferedImage, Integer> weights`: Maps each sprite to its weight.
+    - `OpenSimplex2S noise`: Generates noise for AO shading.
+
+  When the **AO** checkbox is selected, the following parameters modify the output:
+    - `Radius`: Blur radius for shadow spreading (default 8).
+    - `Depth`: Intensity multiplier for the darkening effect (default 0.01).
+    - `Scale`: Scale factor for the simplex noise mask (default 0.5).
+    - `Threshold`: Minimum noise value for shadow application (default 0.5).
 
 - **Methods:**
     - `void openConfigDialog()`: Opens a dialog for configuring scatter parameters and uploading sprites.
     - `ImagePair executeOperation(ImagePair input, Parameters par)`: Executes the scatter operation based on the input and par.
+    - `BufferedImage blur(BufferedImage img, int radius)`: Utility for Gaussian blur when AO is enabled.
     
 #### ConfigureScatterDialog.java
 - **Properties:**

--- a/Textures/software_requirements_document.txt
+++ b/Textures/software_requirements_document.txt
@@ -61,6 +61,7 @@ Textures is a Java application that provides functionalities for creating and ma
     4. Toroidal Wrapping: any portion of a pasted sprite crossing an edge reappears on the opposite side.
   - **FR-21.6**: The Add Sprite file chooser shall open in the directory used during the previous sprite load session.
   - **FR-21.7**: The configuration dialog shall provide an "Add 4" button that loads one image and splits it into four sprites automatically.
+  - **FR-21.8**: The Scatter operation shall include an optional **AO** mode. When enabled, additional parameters (Radius, Depth, Scale, Threshold) become available and the operation produces an Ambient Occlusion mask by darkening pixels around each sprite using a blurred Simplex noise pattern.
 
 ### 10. File Menu
 - **FR-22**: The application shall provide a menu bar with a **File** dropdown.

--- a/Textures/src/com/beder/texture/Operation.java
+++ b/Textures/src/com/beder/texture/Operation.java
@@ -15,6 +15,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSlider;
 import javax.swing.JTextField;
+import javax.swing.JCheckBox;
 
 public abstract class Operation implements Comparable<Operation> {
         private Parameters param;
@@ -23,7 +24,7 @@ public abstract class Operation implements Comparable<Operation> {
         private Map<String, Component> controls;
         /** Text field used when a SEED parameter is added. */
         protected JTextField seedField;
-	protected enum CONTROL_TYPE {INT, DOUBLE, SLIDER, SEED};
+        protected enum CONTROL_TYPE {INT, DOUBLE, SLIDER, SEED, BOOLEAN};
 	
 	public Operation(Redrawable redraw){
 		this.redraw = redraw;
@@ -46,18 +47,24 @@ public abstract class Operation implements Comparable<Operation> {
 			break;
             case SLIDER:
                 JSlider slider = new JSlider(0, 100, (int) def);
-	        slider.setMajorTickSpacing(20);
-	        slider.setMinorTickSpacing(5);
-	        slider.setPaintTicks(true);
-	        slider.setPaintLabels(true);
-	        controls.put(name, slider);
-	        controlPanel.add(slider);
-	        break;
-                case SEED:
-                    seedField = new JTextField(String.format("%d", (long)def), 8);
-                    controls.put(name, seedField);
-                    controlPanel.add(seedField);
-                    JButton randomSeedButton = new JButton("Random");
+                slider.setMajorTickSpacing(20);
+                slider.setMinorTickSpacing(5);
+                slider.setPaintTicks(true);
+                slider.setPaintLabels(true);
+                controls.put(name, slider);
+                controlPanel.add(slider);
+                break;
+            case BOOLEAN:
+                JCheckBox cb = new JCheckBox();
+                cb.setSelected(def != 0);
+                controls.put(name, cb);
+                controlPanel.add(cb);
+                break;
+            case SEED:
+                seedField = new JTextField(String.format("%d", (long)def), 8);
+                controls.put(name, seedField);
+                controlPanel.add(seedField);
+                JButton randomSeedButton = new JButton("Random");
                     randomSeedButton.addActionListener(e -> {
                         String newSeed = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
                         seedField.setText(newSeed);
@@ -78,13 +85,16 @@ public abstract class Operation implements Comparable<Operation> {
 	        String name = entry.getKey();
 	        Component c = entry.getValue();
 	        try {
-	            if (c instanceof JTextField) {
-	                JTextField tf = (JTextField)c;
-	                param.put(name, Double.parseDouble(tf.getText()));
-	            } else if (c instanceof JSlider) {
-	                JSlider s = (JSlider)c;
-	                param.put(name, (double)s.getValue());
-	            }
+                    if (c instanceof JTextField) {
+                        JTextField tf = (JTextField)c;
+                        param.put(name, Double.parseDouble(tf.getText()));
+                    } else if (c instanceof JSlider) {
+                        JSlider s = (JSlider)c;
+                        param.put(name, (double)s.getValue());
+                    } else if (c instanceof JCheckBox) {
+                        JCheckBox cb = (JCheckBox)c;
+                        param.put(name, cb.isSelected() ? 1.0 : 0.0);
+                    }
 	        } catch (NumberFormatException e) {
 	            System.err.println("Invalid input for parameter: " + name);
 	        }

--- a/Textures/src/com/beder/texture/scatter/ScatterOperation.java
+++ b/Textures/src/com/beder/texture/scatter/ScatterOperation.java
@@ -1,17 +1,44 @@
 package com.beder.texture.scatter;
 
+import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
+import java.awt.image.BufferedImageOp;
+import java.awt.image.ConvolveOp;
+import java.awt.image.Kernel;
 import java.util.Random;
 
 import com.beder.texture.ImagePair;
 import com.beder.texture.Operation;
 import com.beder.texture.Parameters;
 import com.beder.texture.Redrawable;
+import com.beder.util.OpenSimplex2S;
 
 public class ScatterOperation extends Operation {
+    private final OpenSimplex2S noise = new OpenSimplex2S();
+
+    private static BufferedImage blur(BufferedImage img, int radius) {
+        if (radius <= 0) return img;
+        int size = radius * 2 + 1;
+        float[] data = new float[size * size];
+        float sigma = radius / 3f;
+        float sum = 0f;
+        for (int y = -radius; y <= radius; y++) {
+            for (int x = -radius; x <= radius; x++) {
+                float val = (float)Math.exp(-(x*x + y*y) / (2*sigma*sigma));
+                data[(y + radius) * size + (x + radius)] = val;
+                sum += val;
+            }
+        }
+        for (int i = 0; i < data.length; i++) data[i] /= sum;
+        Kernel kernel = new Kernel(size, size, data);
+        BufferedImageOp op = new ConvolveOp(kernel, ConvolveOp.EDGE_NO_OP, null);
+        BufferedImage out = new BufferedImage(img.getWidth(), img.getHeight(), BufferedImage.TYPE_INT_ARGB);
+        op.filter(img, out);
+        return out;
+    }
 
     public ScatterOperation(Redrawable redraw) {
         super(redraw);
@@ -19,6 +46,11 @@ public class ScatterOperation extends Operation {
         addParameter("Size", CONTROL_TYPE.INT, 64);
         addParameter("StdDev", CONTROL_TYPE.DOUBLE, 10.0);
         addParameter("Seed", CONTROL_TYPE.SEED, new Random().nextLong());
+        addParameter("AO", CONTROL_TYPE.BOOLEAN, 0);
+        addParameter("Radius", CONTROL_TYPE.INT, 8);
+        addParameter("Depth", CONTROL_TYPE.DOUBLE, 0.01);
+        addParameter("Scale", CONTROL_TYPE.DOUBLE, 0.5);
+        addParameter("Threshold", CONTROL_TYPE.DOUBLE, 0.5);
     }
 
     @Override
@@ -28,6 +60,11 @@ public class ScatterOperation extends Operation {
         int meanSize  = (int) par.get("Size",     64);
         double stdDev =      par.get("StdDev",   10.0);
         long seed     =   (long) par.get("Seed",    System.currentTimeMillis());
+        boolean aoEnabled = par.get("AO", 0) > 0.5;
+        int radius   = (int) par.get("Radius", 8);
+        double depth =      par.get("Depth", 0.01);
+        double noiseScale = par.get("Scale", 0.5);
+        double threshold  = par.get("Threshold", 0.5);
         Random rnd    = new Random(seed);
 
         // 2. Fetch sprites
@@ -39,6 +76,12 @@ public class ScatterOperation extends Operation {
 
         int res = getRedraw().getRes();
         BufferedImage canvas = new BufferedImage(res, res, BufferedImage.TYPE_INT_ARGB);
+        if (aoEnabled) {
+            Graphics2D g = canvas.createGraphics();
+            g.setColor(Color.WHITE);
+            g.fillRect(0, 0, res, res);
+            g.dispose();
+        }
         input.left = canvas;
 
         for (int i = 0; i < quantity; i++) {
@@ -71,17 +114,59 @@ public class ScatterOperation extends Operation {
             int x0 = rnd.nextInt(res);
             int y0 = rnd.nextInt(res);
 
-            // 8. Paste with toroidal wrap: pixel‐by‐pixel
-            for (int y = 0; y < transformed.getHeight(); y++) {
-                for (int x = 0; x < transformed.getWidth(); x++) {
-                    int argb = transformed.getRGB(x, y);
-                    int alpha = (argb >>> 24) & 0xFF;
-                    if (alpha == 0) continue; // skip fully transparent
-                    int dx = (x0 + x) % res;
-                    if (dx < 0) dx += res;
-                    int dy = (y0 + y) % res;
-                    if (dy < 0) dy += res;
-                    canvas.setRGB(dx, dy, argb);
+            if (!aoEnabled) {
+                // 8. Paste with toroidal wrap: pixel‐by‐pixel
+                for (int y = 0; y < transformed.getHeight(); y++) {
+                    for (int x = 0; x < transformed.getWidth(); x++) {
+                        int argb = transformed.getRGB(x, y);
+                        int alpha = (argb >>> 24) & 0xFF;
+                        if (alpha == 0) continue;
+                        int dx = (x0 + x) % res;
+                        if (dx < 0) dx += res;
+                        int dy = (y0 + y) % res;
+                        if (dy < 0) dy += res;
+                        canvas.setRGB(dx, dy, argb);
+                    }
+                }
+            } else {
+                int ext = size + radius * 2;
+                BufferedImage mask = new BufferedImage(ext, ext, BufferedImage.TYPE_INT_ARGB);
+                Graphics2D mg = mask.createGraphics();
+                mg.drawImage(transformed, radius, radius, null);
+                mg.dispose();
+                BufferedImage blurred = blur(mask, radius);
+                for (int y = 0; y < ext; y++) {
+                    for (int x = 0; x < ext; x++) {
+                        int alpha = (blurred.getRGB(x, y) >>> 24) & 0xFF;
+                        if (alpha == 0) continue;
+                        int dx = (x0 + x - radius) % res;
+                        if (dx < 0) dx += res;
+                        int dy = (y0 + y - radius) % res;
+                        if (dy < 0) dy += res;
+                        double val = alpha / 255.0;
+                        double n = (noise.noise2(seed, (dx) / noiseScale, (dy) / noiseScale) + 1) / 2.0;
+                        n = (n - threshold) / (1 - threshold);
+                        if (n < 0) n = 0;
+                        val *= n * depth;
+                        int rgb = canvas.getRGB(dx, dy);
+                        int gray = (rgb >> 16) & 0xFF;
+                        int newGray = (int) Math.max(0, gray - val * 255);
+                        int newRgb = 0xFF000000 | (newGray << 16) | (newGray << 8) | newGray;
+                        canvas.setRGB(dx, dy, newRgb);
+                    }
+                }
+                // write sprite itself as white
+                for (int y = 0; y < size; y++) {
+                    for (int x = 0; x < size; x++) {
+                        int argb = transformed.getRGB(x, y);
+                        int alpha = (argb >>> 24) & 0xFF;
+                        if (alpha == 0) continue;
+                        int dx = (x0 + x) % res;
+                        if (dx < 0) dx += res;
+                        int dy = (y0 + y) % res;
+                        if (dy < 0) dy += res;
+                        canvas.setRGB(dx, dy, 0xFFFFFFFF);
+                    }
                 }
             }
         }

--- a/Textures/src/test/java/test/ScatterAOTest.java
+++ b/Textures/src/test/java/test/ScatterAOTest.java
@@ -1,0 +1,50 @@
+package test;
+
+import com.beder.texture.ImagePair;
+import com.beder.texture.Parameters;
+import com.beder.texture.Redrawable;
+import com.beder.texture.scatter.ScatterOperation;
+import com.beder.texture.scatter.SpriteRepository;
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.BufferedImage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ScatterAOTest {
+    private final Redrawable dummy = new Redrawable() {
+        public void applyImage(ImagePair pair) {}
+        public int getRes() { return 16; }
+        public void mouseClicked(java.awt.event.MouseEvent e) {}
+        public void mousePressed(java.awt.event.MouseEvent e) {}
+        public void mouseReleased(java.awt.event.MouseEvent e) {}
+        public void mouseEntered(java.awt.event.MouseEvent e) {}
+        public void mouseExited(java.awt.event.MouseEvent e) {}
+    };
+
+    @Test
+    public void aoModeDarkensPixels() {
+        SpriteRepository repo = SpriteRepository.getInstance();
+        repo.clear();
+        BufferedImage img = new BufferedImage(2,2,BufferedImage.TYPE_INT_ARGB);
+        for(int y=0;y<2;y++) for(int x=0;x<2;x++) img.setRGB(x,y,0xFFFFFFFF);
+        repo.addSprite(img,1);
+
+        ScatterOperation op = new ScatterOperation(dummy);
+        Parameters p = new Parameters();
+        p.put("Quantity", 1.0);
+        p.put("Size", 2.0);
+        p.put("StdDev", 0.0);
+        p.put("Seed", 0.0);
+        p.put("AO", 1.0);
+        p.put("Radius", 3.0);
+        p.put("Depth", 1.0);
+        p.put("Scale", 1.0);
+        p.put("Threshold", 0.0);
+
+        ImagePair pair = new ImagePair(16);
+        op.executeOperation(pair, p);
+
+        assertNotNull(pair.left);
+    }
+}


### PR DESCRIPTION
## Summary
- support BOOLEAN parameter type for Operation controls
- add AO shading settings and algorithm to ScatterOperation
- document new AO mode in design and requirements docs
- include basic test for AO parameter usage

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68463eba218483278996882d5766b963